### PR TITLE
Handle disconnect event using a simple channel

### DIFF
--- a/client.go
+++ b/client.go
@@ -332,10 +332,8 @@ func clearConnection(c *rpc2.Client) {
 
 func handleDisconnectNotification(c *rpc2.Client) {
 	disconnected := c.DisconnectNotify()
-	select {
-	case <-disconnected:
-		clearConnection(c)
-	}
+	<-disconnected
+	clearConnection(c)
 }
 
 // Disconnect will close the OVSDB connection


### PR DESCRIPTION
This commit handles the disconnect event using a simple channel instead
of of a select statement with a single case

Signed-off-by: Vandewilly Silva <vandewilly.oli.silva@hpe.com>